### PR TITLE
Changed get_listing function to include up to 500 records in each req…

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,14 @@ The script depends on [JSON.sh](https://github.com/dominictarr/JSON.sh), and
 will download a copy into the current directory (pinned to a known SHA) if it
 doesn't exist.  If your deploy won't have write access, download it and give it
 executable permissions in the same directory.
+
+## Example Usage
+ ### Basic
+ ```bash
+./do-dns 203.0.113.25
+```
+ ### Actual Use: ASUS Router w/ [Padavan Firmware](https://bitbucket.org/padavan/rt-n56u)
+ ```bash
+./do-ddns $(ifconfig eth2.2 | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')
+```
+ This command uses the IP address of the device's eth2.2 interface as do-ddns' IP address parameter.

--- a/do-ddns
+++ b/do-ddns
@@ -93,7 +93,7 @@ req() {
 }
 
 get_listing() {
-  JSON=$(req "https://api.digitalocean.com/v2/domains/$DOMAIN/records")
+  JSON=$(req "https://api.digitalocean.com/v2/domains/$DOMAIN/records?per_page=500")
   ALL=$(echo "$JSON" | "$JSON_sh" -b)
 
   # Find the line for the domain that includes the name we've configured


### PR DESCRIPTION
Changed get_listing function to include up to 500 records in each request. Fixes issue where do-ddns doesn't see existing records and calls create_record instead of update_record.